### PR TITLE
Custom image support for map pins + bug fixes

### DIFF
--- a/src/ios/MKComplexMapPin.h
+++ b/src/ios/MKComplexMapPin.h
@@ -12,19 +12,19 @@
 {
     CGFloat mapId;
     CGFloat pinColor;
+    BOOL customImage;
+    NSString* pinImage;
     BOOL draggable;
     BOOL canShowCallout;
     BOOL showInfoButton;
-    BOOL customImage;
-    NSString* imageLocation;
 }
 
 @property(nonatomic, readwrite) CGFloat mapId;
 @property(nonatomic, readwrite) CGFloat pinColor;
+@property(nonatomic, readwrite) BOOL customImage;
+@property(nonatomic, readwrite) NSString* pinImage;
 @property(nonatomic, readwrite) BOOL draggable;
 @property(nonatomic, readwrite) BOOL canShowCallout;
 @property(nonatomic, readwrite) BOOL showInfoButton;
-@property(nonatomic, readwrite) BOOL customImage;
-@property(nonatomic, readwrite) NSString* imageLocation;
 
 @end

--- a/src/ios/MKComplexMapPin.h
+++ b/src/ios/MKComplexMapPin.h
@@ -14,6 +14,8 @@
     CGFloat pinColor;
     BOOL customImage;
     NSString* pinImage;
+    CGFloat pinImageOffsetX;
+    CGFloat pinImageOffsetY;
     BOOL draggable;
     BOOL canShowCallout;
     BOOL showInfoButton;
@@ -23,6 +25,8 @@
 @property(nonatomic, readwrite) CGFloat pinColor;
 @property(nonatomic, readwrite) BOOL customImage;
 @property(nonatomic, readwrite) NSString* pinImage;
+@property(nonatomic, readwrite) CGFloat pinImageOffsetX;
+@property(nonatomic, readwrite) CGFloat pinImageOffsetY;
 @property(nonatomic, readwrite) BOOL draggable;
 @property(nonatomic, readwrite) BOOL canShowCallout;
 @property(nonatomic, readwrite) BOOL showInfoButton;

--- a/src/ios/MapKit.m
+++ b/src/ios/MapKit.m
@@ -668,9 +668,10 @@ UIWebView* webView;
     NSString* title = [[command arguments] objectAtIndex:3];
     NSString* description = [[command arguments] objectAtIndex:4];
     CGFloat pinColor = [[[command arguments] objectAtIndex:5] floatValue];
-    CGFloat draggable = [[[command arguments] objectAtIndex:6] floatValue];
-    CGFloat canShowCallout = [[[command arguments] objectAtIndex:7] floatValue];
-    CGFloat showInfoButton = [[[command arguments] objectAtIndex:8] floatValue];
+    NSString* pinImage = [[command arguments] objectAtIndex:6];
+    CGFloat draggable = [[[command arguments] objectAtIndex:7] floatValue];
+    CGFloat canShowCallout = [[[command arguments] objectAtIndex:8] floatValue];
+    CGFloat showInfoButton = [[[command arguments] objectAtIndex:9] floatValue];
 //    CGFloat inaccuracyRadius = [[[command arguments] objectAtIndex:6]floatValue];
     MKMapView* mapView = [self.webView viewWithTag:mapId];
 
@@ -699,6 +700,11 @@ UIWebView* webView;
     else
     {
         pinAnnotation.pinColor = MKPinAnnotationColorRed;
+    }
+    
+    if ([pinImage length] != 0) {
+        pinAnnotation.customImage = YES;
+        pinAnnotation.pinImage = pinImage;
     }
 
     if (draggable > 0)
@@ -802,37 +808,35 @@ UIWebView* webView;
     MKPinAnnotationView *pav = (MKPinAnnotationView *)[mapView dequeueReusableAnnotationViewWithIdentifier:reuseId];
     if (pav == nil)
     {
-        if ([annotation isKindOfClass:[MKComplexMapPin class]])
-        {
-            pav = [[MKPinAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:reuseId];
-
-            MKComplexMapPin *pin = (MKComplexMapPin *)annotation;
-            pav.pinColor = pin.pinColor;
-            pav.draggable = pin.draggable;
-            pav.canShowCallout = pin.canShowCallout;
-
-            if (pin.showInfoButton)
-            {
-              UIButton* info = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
-              pav.rightCalloutAccessoryView = info;
-            }
-        }
-        else if ([annotation isKindOfClass:[MKPointAnnotation class]])
-        {
-            pav = [[MKPinAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:reuseId];
-
-            pav.canShowCallout = YES;
-        }
-
-
-//        pav.draggable = YES;
-//        pav.canShowCallout = YES;
-//        MKComplexMapPin* pinAnnotation = [mapView ];
-//        pav.pinColor = pinAnnotation.pinColor;
+        pav = [[MKPinAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:reuseId];
     }
     else
     {
         pav.annotation = annotation;
+    }
+    
+    if ([annotation isKindOfClass:[MKComplexMapPin class]])
+    {
+        MKComplexMapPin *pin = (MKComplexMapPin *)annotation;
+        pav.pinColor = pin.pinColor;
+        pav.draggable = pin.draggable;
+        pav.canShowCallout = pin.canShowCallout;
+        
+        if (pin.customImage) {
+            NSURL *url = [NSURL URLWithString:pin.pinImage];
+            NSData *imageData = [NSData dataWithContentsOfURL:url];
+            pav.image = [UIImage imageWithData:imageData];
+        }
+        
+        if (pin.showInfoButton)
+        {
+            UIButton* info = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+            pav.rightCalloutAccessoryView = info;
+        }
+    }
+    else if ([annotation isKindOfClass:[MKPointAnnotation class]])
+    {
+        pav.canShowCallout = YES;
     }
 
     return pav;

--- a/www/mapkit.js
+++ b/www/mapkit.js
@@ -284,10 +284,13 @@ var MKMap = function (mapId) {
     }
   }
   this.destroyMap = function () {
-    console.log("#MKMap(" + this.mapId + ") Destroying map")
-    this.destroyed = true
-    that = this
-    cordovaRef.exec(this.execSuccess, this.execFailure, 'MapKit', 'removeMapView', [this.mapArrayId])
+    if (!this.destroyed)
+    {
+      console.log("#MKMap(" + this.mapId + ") Destroying map")
+      this.destroyed = true
+      that = this
+      cordovaRef.exec(this.execSuccess, this.execFailure, 'MapKit', 'removeMapView', [this.mapArrayId])
+    }
   }
   this.showMap = function () {
     console.log("#MKMap(" + this.mapId + ") Showing map")

--- a/www/mapkit.js
+++ b/www/mapkit.js
@@ -94,13 +94,14 @@ var MKSimplePin = function (map, lat, lon, title, description) {
   }
 }
 
-var MKComplexPin = function (map, lat, lon, title, description, pinColor, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback) {
+var MKComplexPin = function (map, lat, lon, title, description, pinColor, pinImage, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback) {
   this.map = map
   this.lat = lat
   this.lon = lon
   this.title = title
   this.description = description
   this.pinColor = pinColor
+  this.pinImage = pinImage
   this.draggable = draggable
   this.canShowCallout = canShowCallout
   this.showInfoButton = showInfoButton
@@ -117,7 +118,7 @@ var MKComplexPin = function (map, lat, lon, title, description, pinColor, dragga
   this.createPin = function () {
     that = this
     console.log("Creating pin: ${[this.map.mapArrayId, this.lat, this.lon, this.title, this.description].join(" - ")}")
-    cordovaRef.exec(this.execSuccess, this.execFailure, 'MapKit', 'addComplexMapPin', [this.map.mapArrayId, this.lat, this.lon, this.title, this.description, ((this.pinColor == "purple")?3:((this.pinColor == "green")?2:1)), ((this.draggable)?1:0), ((this.canShowCallout)?1:0), ((this.showInfoButton)?1:0)])
+    cordovaRef.exec(this.execSuccess, this.execFailure, 'MapKit', 'addComplexMapPin', [this.map.mapArrayId, this.lat, this.lon, this.title, this.description, ((this.pinColor == "purple")?3:((this.pinColor == "green")?2:1)), this.pinImage, ((this.draggable)?1:0), ((this.canShowCallout)?1:0), ((this.showInfoButton)?1:0)])
   }
   this.createPinArray = function () {
     return [this.lat, this.lon, this.title, this.description]
@@ -431,6 +432,7 @@ var MKMap = function (mapId) {
     title = data.title || ("Pin " + this.PinsArray.length)
     description = data.description || ""
     pinColor = data.pinColor || "red" // red/green/purple
+    pinImage = data.pinImage || ""
     draggable = data.draggable || false;
     canShowCallout = data.canShowCallout || true;
     showInfoButton = data.showInfoButton || false;
@@ -441,7 +443,7 @@ var MKMap = function (mapId) {
     {
       this.Pins[title].removePin()
     }
-    Pin = new MKComplexPin(this, lat, lon, title, description, pinColor, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback)
+    Pin = new MKComplexPin(this, lat, lon, title, description, pinColor, pinImage, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback)
     this.Pins[title] = Pin
     this.PinsArray.push(Pin)
     Pin.createPin()

--- a/www/mapkit.js
+++ b/www/mapkit.js
@@ -437,9 +437,9 @@ var MKMap = function (mapId) {
     pinImage = data.pinImage || ""
     pinImageOffsetX = data.pinImageOffsetX || 0
     pinImageOffsetY = data.pinImageOffsetY || 0
-    draggable = data.draggable || false;
-    canShowCallout = data.canShowCallout || true;
-    showInfoButton = data.showInfoButton || false;
+    draggable = data.draggable === true;
+    canShowCallout = data.canShowCallout !== false;
+    showInfoButton = data.showInfoButton === true;
     pinDragCallback = data.pinDragCallback || function (pin) { console.log("Pin was moved: "+pin.title) }
     infoClickCallback = data.infoClickCallback || function (pin) { console.log("PinInfo was clicked: "+pin.title) }
 

--- a/www/mapkit.js
+++ b/www/mapkit.js
@@ -94,7 +94,7 @@ var MKSimplePin = function (map, lat, lon, title, description) {
   }
 }
 
-var MKComplexPin = function (map, lat, lon, title, description, pinColor, pinImage, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback) {
+var MKComplexPin = function (map, lat, lon, title, description, pinColor, pinImage, pinImageOffsetX, pinImageOffsetY, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback) {
   this.map = map
   this.lat = lat
   this.lon = lon
@@ -102,6 +102,8 @@ var MKComplexPin = function (map, lat, lon, title, description, pinColor, pinIma
   this.description = description
   this.pinColor = pinColor
   this.pinImage = pinImage
+  this.pinImageOffsetX = pinImageOffsetX
+  this.pinImageOffsetY = pinImageOffsetY
   this.draggable = draggable
   this.canShowCallout = canShowCallout
   this.showInfoButton = showInfoButton
@@ -118,7 +120,7 @@ var MKComplexPin = function (map, lat, lon, title, description, pinColor, pinIma
   this.createPin = function () {
     that = this
     console.log("Creating pin: ${[this.map.mapArrayId, this.lat, this.lon, this.title, this.description].join(" - ")}")
-    cordovaRef.exec(this.execSuccess, this.execFailure, 'MapKit', 'addComplexMapPin', [this.map.mapArrayId, this.lat, this.lon, this.title, this.description, ((this.pinColor == "purple")?3:((this.pinColor == "green")?2:1)), this.pinImage, ((this.draggable)?1:0), ((this.canShowCallout)?1:0), ((this.showInfoButton)?1:0)])
+    cordovaRef.exec(this.execSuccess, this.execFailure, 'MapKit', 'addComplexMapPin', [this.map.mapArrayId, this.lat, this.lon, this.title, this.description, ((this.pinColor == "purple")?3:((this.pinColor == "green")?2:1)), this.pinImage, this.pinImageOffsetX, this.pinImageOffsetY, ((this.draggable)?1:0), ((this.canShowCallout)?1:0), ((this.showInfoButton)?1:0)])
   }
   this.createPinArray = function () {
     return [this.lat, this.lon, this.title, this.description]
@@ -433,6 +435,8 @@ var MKMap = function (mapId) {
     description = data.description || ""
     pinColor = data.pinColor || "red" // red/green/purple
     pinImage = data.pinImage || ""
+    pinImageOffsetX = data.pinImageOffsetX || 0
+    pinImageOffsetY = data.pinImageOffsetY || 0
     draggable = data.draggable || false;
     canShowCallout = data.canShowCallout || true;
     showInfoButton = data.showInfoButton || false;
@@ -443,7 +447,7 @@ var MKMap = function (mapId) {
     {
       this.Pins[title].removePin()
     }
-    Pin = new MKComplexPin(this, lat, lon, title, description, pinColor, pinImage, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback)
+    Pin = new MKComplexPin(this, lat, lon, title, description, pinColor, pinImage, pinImageOffsetX, pinImageOffsetY, draggable, canShowCallout, showInfoButton, pinDragCallback, infoClickCallback)
     this.Pins[title] = Pin
     this.PinsArray.push(Pin)
     Pin.createPin()


### PR DESCRIPTION
- Added custom image support for map pins. Instead of image path, provide the image data URL - anything supported by iOS UIImage, e.g. base64 string of PNG image.
- Offset can now be set for map pins that uses custom image with non-centered anchor point.
- Fixed a bug where draggable/canShowCallout/showInfoButton settings does not take effect
- Calling destroyMap will do nothing if map is already destroyed
